### PR TITLE
Added option to disable pretty URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+### This is a fork which adds an [option to disable pretty URLs](https://github.com/paulwib/gulp-ssg/pull/2).
+
 A [gulp][] plugin to generate a static site.
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function(site, options) {
             isIndex: isIndex,
             isHome: isHome,
             url: fileUrl,
-            sectionUrl: sectionUrl(fileUrl, isIndex, file) // TODO
+            sectionUrl: sectionUrl(fileUrl, isIndex, file)
         }, file[options.property] || {});
 
         buffer.push(file);

--- a/index.js
+++ b/index.js
@@ -252,8 +252,16 @@ module.exports = function(website, options) {
      * @return string url
      */
     function url(file, baseUrl) {
-        var dirname = path.dirname(file.relative).replace(/\\/g, '/');
-        return baseUrl + '/' + dirname.replace(/^\.\//, '') + '/';
+        var dirname = path.dirname(file.relative).replace(/\\/g, '/'),
+            basename = path.basename(file.relative, path.extname(file.relative));
+
+        if (options.prettyUrls === false || path.extname(file.relative) === '.html')
+        {
+            return baseUrl + '/' + dirname.replace(/^\.\//, '') + '/';
+        }
+        else {
+            return baseUrl + '/' + file.relative;
+        }
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function(site, options) {
             isIndex: isIndex,
             isHome: isHome,
             url: fileUrl,
-            sectionUrl: sectionUrl(fileUrl, isIndex)
+            sectionUrl: sectionUrl(fileUrl, isIndex, file) // TODO
         }, file[options.property] || {});
 
         buffer.push(file);
@@ -209,7 +209,8 @@ module.exports = function(site, options) {
      * @param object index The content tree
      */
     function addSectionToFiles(index) {
-        if (!index.files.length) {
+        
+        if (!index.files) {
             return;
         }
         index.files.forEach(function(file) {
@@ -265,8 +266,22 @@ module.exports = function(site, options) {
      * @param object file
      * @return string url
      */
-    function sectionUrl(url, isIndex) {
-        return isIndex ? url : url.split('/').slice(0, -2).join('/') + '/';
+    function sectionUrl(url, isIndex, file) {
+        var basename = path.basename(file.relative, path.extname(file.relative));
+        var result = isIndex ? url : url.split('/').slice(0, -2).join('/') + '/';
+
+        if (basename !== 'index') // which will only happen when in non prettyUrl mode
+        {
+            if(url === '/./'){
+                result = '/' 
+            }
+            else {
+                result = url.split('/').slice(0, -1).join('/') + '/';
+            }
+        }
+        return result
+
+
     }
 
 };

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ module.exports = function(site, options) {
                 '/index.html';            
         }
         else {
-            file.path = file.base + dirname + '/' + file.relative;
+            file.path = file.base + dirname + '/' + basename + path.extname(file.relative); 
         }
 
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ module.exports = function(site, options) {
         baseUrl: '',
         sort: 'url',
         property: 'meta',
-        sectionProperties: []
+        sectionProperties: [],
+        prettyUrls: true
     }, options || {});
 
     var buffer = [];
@@ -233,9 +234,16 @@ module.exports = function(site, options) {
         var dirname = path.dirname(file.relative),
             basename = path.basename(file.relative, path.extname(file.relative));
 
-        file.path = file.base +
-            (basename !== 'index' ? dirname + '/' + basename : dirname) +
-            '/index.html';
+        if (options.prettyUrls)
+        {
+            file.path = file.base +
+                (basename !== 'index' ? dirname + '/' + basename : dirname) +
+                '/index.html';            
+        }
+        else {
+            file.path = file.base + dirname + '/' + file.relative;
+        }
+
 
         return dirname;
     }

--- a/index.js
+++ b/index.js
@@ -234,7 +234,7 @@ module.exports = function(site, options) {
         var dirname = path.dirname(file.relative),
             basename = path.basename(file.relative, path.extname(file.relative));
 
-        if (options.prettyUrls)
+        if (options.prettyUrls === true || options.prettyUrls === path.extname(file.relative))
         {
             file.path = file.base +
                 (basename !== 'index' ? dirname + '/' + basename : dirname) +

--- a/test/test.js
+++ b/test/test.js
@@ -42,8 +42,6 @@ describe('gulp-ssg()', function() {
             stream.end();
         });
 
-        // Zach ----------------------------------------------------
-
         it('in prettyUrls false mode, should not rename paths', function(done) {
             var site = {};
             var options = {prettyUrls: '.md'}

--- a/test/test.js
+++ b/test/test.js
@@ -42,6 +42,38 @@ describe('gulp-ssg()', function() {
             stream.end();
         });
 
+        // Zach ----------------------------------------------------
+
+        it('in prettyUrls false mode, should not rename paths', function(done) {
+            // var stream = ssg({});
+            var site = {};
+            var options = {prettyUrls:false}
+            var stream = ssg(site, options);
+
+            var file = getMarkdownFile('test/hello.png', 'test');
+            var pic = getMarkdownFile('test/sub/f/picture.png', 'test');
+
+            stream.on('end', function() {
+                var newFilePath = path.resolve(file.path);
+                var expectedFilePath = path.resolve('test/hello.png');
+                newFilePath.should.equal(expectedFilePath);
+                file.relative.should.equal('hello.png');
+                Buffer.isBuffer(file.contents).should.equal(true);
+
+                var newPicPath = path.resolve(pic.path);
+                var expectedPicPath = path.resolve('test/sub/f/picture.png');
+                newPicPath.should.equal(expectedPicPath);
+                pic.relative.should.equal('sub/f/picture.png');
+                Buffer.isBuffer(pic.contents).should.equal(true);
+
+                done();
+            });
+
+            stream.write(file);
+            stream.end();
+        });
+
+
         it('should rename non-indexes to path/basename/index.html', function(done) {
             var stream = ssg({});
             var file = getMarkdownFile('test/hello.md', 'test');

--- a/test/test.js
+++ b/test/test.js
@@ -45,13 +45,13 @@ describe('gulp-ssg()', function() {
         // Zach ----------------------------------------------------
 
         it('in prettyUrls false mode, should not rename paths', function(done) {
-            // var stream = ssg({});
             var site = {};
-            var options = {prettyUrls:false}
+            var options = {prettyUrls: '.md'}
             var stream = ssg(site, options);
 
             var file = getMarkdownFile('test/hello.png', 'test');
             var pic = getMarkdownFile('test/sub/f/picture.png', 'test');
+            var actualMd = getMarkdownFile('test/text.md', 'test');
 
             stream.on('end', function() {
                 var newFilePath = path.resolve(file.path);
@@ -66,10 +66,18 @@ describe('gulp-ssg()', function() {
                 pic.relative.should.equal('sub/f/picture.png');
                 Buffer.isBuffer(pic.contents).should.equal(true);
 
+                var mdPath = path.resolve(actualMd.path);
+                var expectedMdPath = path.resolve('test/text/index.html');
+                mdPath.should.equal(expectedMdPath);
+                actualMd.relative.should.equal('text/index.html');
+                Buffer.isBuffer(actualMd.contents).should.equal(true);
+
                 done();
             });
 
             stream.write(file);
+            stream.write(pic);
+            stream.write(actualMd);
             stream.end();
         });
 

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,7 @@ describe('gulp-ssg()', function() {
 
         it('in prettyUrls false mode, should not rename paths', function(done) {
             var site = {};
-            var options = {prettyUrls: '.md'}
+            var options = {prettyUrls: '.md'};
             var stream = ssg(site, options);
 
             var file = getMarkdownFile('test/hello.png', 'test');
@@ -52,18 +52,22 @@ describe('gulp-ssg()', function() {
                 var expectedFilePath = path.resolve('test/hello.png');
                 newFilePath.should.equal(expectedFilePath);
                 file.relative.should.equal('hello.png');
+                file.data.url.should.equal('/hello.png');
                 Buffer.isBuffer(file.contents).should.equal(true);
 
                 var newPicPath = path.resolve(pic.path);
                 var expectedPicPath = path.resolve('test/sub/f/picture.png');
                 newPicPath.should.equal(expectedPicPath);
                 pic.relative.should.equal('sub/f/picture.png');
+                pic.data.url.should.equal('/sub/f/picture.png');
                 Buffer.isBuffer(pic.contents).should.equal(true);
 
                 var mdPath = path.resolve(actualMd.path);
                 var expectedMdPath = path.resolve('test/text/index.html');
                 mdPath.should.equal(expectedMdPath);
                 actualMd.relative.should.equal('text/index.html');
+                actualMd.data.url.should.equal('/text/');
+
                 Buffer.isBuffer(actualMd.contents).should.equal(true);
 
                 done();


### PR DESCRIPTION
No idea if you're interested in merging this in, but I added this option because I wanted to use this plugin for indexing media content (i.e. not just html and markdown). 

Basically, if `prettyUrls` is set to false, files won't be renamed to `name/index.html` and will keep their original filename . If prettyUrls is set to a file extension, like `.md`, then only files ending in that extension will be renamed to `name/index.html`.